### PR TITLE
sys/io.h is not available on every architecture

### DIFF
--- a/vlbi/stream.cpp
+++ b/vlbi/stream.cpp
@@ -17,7 +17,6 @@
 */
 
 #ifndef _WIN32
-#include <sys/io.h>
 #include <linux/fcntl.h>
 #endif
 #include <stdio.h>


### PR DESCRIPTION
sys/io.h is not available on every architecture
As it does not seem to be used, it can be just removed to make OpenVLBI available on all architectures.